### PR TITLE
specification: Add Ravi and Ved to the list of contributors

### DIFF
--- a/specification/01-contributors.adoc
+++ b/specification/01-contributors.adoc
@@ -5,3 +5,5 @@ This RISC-V specification has been contributed to directly or indirectly by:
 [%hardbreaks]
 * Samuel Ortiz <sameo@rivosinc.com>
 * Jiewen Yao <jiewen.yao@intel.com>
+* Ravi Sahita <ravi@rivosinc.com>
+* Vedvyas Shanbhogue <ved@rivosinc.com>


### PR DESCRIPTION
They both contributed before or during the elaboration of this public specification.