### PR TITLE
specification: Consistently use the supervisor domain manager term

### DIFF
--- a/specification/06-arch_overview.adoc
+++ b/specification/06-arch_overview.adoc
@@ -16,7 +16,7 @@ and is the confidential supervisor domain manager. It uses the <<Smmtt>>
 specified Memory Tracking Table (MTT) to enforce TVM memory isolation from
 the host supervisor domain.
 
-As the confidential security domain manager, the TSM provides the `COVH` ABI
+As the confidential supervisor domain manager, the TSM provides the `COVH` ABI
 for the host OS/VMM to create and destroy TVMs, and donate or reclaim
 confidential memory from them. TVMs can interact with the TSM through the
 `COVG` ABI.
@@ -29,10 +29,10 @@ interfaces (TDI) and TVMs together.
 With the CoVE-IO ABIs and flows, TDIs can access TVM confidential memory
 directly. Based on the TVM configuration, the confidential DMA memory
 could be all TVM memory or a subset of the TVM memory.
-CoVE-IO uses the Smmtt I/O MTT extension and the platform IOMMUs
-security domain specific Register Programming Interfaces (RPI) to grant TDIs
-with direct access to their bound TVM confidential memory and isolate it from
-DMA originating from any unbound TDI.
+CoVE-IO uses the Smmtt I/O MTT extension and the platform IOMMUs supervisor
+domain specific Register Programming Interfaces (RPI) to grant TDIs with direct
+access to their bound TVM confidential memory and isolate it from DMA
+originating from any unbound TDI.
 
 With the CoVE-IO model, the TVM ultimately holds the decision to accept or
 reject a bound TDI into or from its TCB. Access to a TVM confidential memory

--- a/specification/07-theory_operations.adoc
+++ b/specification/07-theory_operations.adoc
@@ -25,7 +25,7 @@ supervisor domain may assign one or more IOMMU instances to the TSM supervisor
 domain, after which, only the TSM can access and program the assigned IOMMU
 instances.
 
-IOMMUs assigned to the TSM security domain may generate MSIs in order to signal
+IOMMUs assigned to the TSM supervisor domain may generate MSIs in order to signal
 the TSM about command completions, transaction faults or device page requests.
 Those MSIs target system physical memory, which is owned by the host security
 domain manager, e.g. the host VMM. As a consequence, it is the host security
@@ -247,7 +247,7 @@ devices is a mandatory requirement for TVMs to accept TDIs into their TCB.
 
 Any trusted I/O SPDM session is established through the SPDM responder DOE
 mailbox in the physical device DSM. The mailbox is resource owned by
-the host security domain manager which thus initiates the SPDM session
+the host supervisor domain manager which thus initiates the SPDM session
 establishment. It acts as an untrusted proxy between the TSM and the DSM by
 requesting the TSM to generate SPDM requests through the CoVIO `COVH`TH ABI,
 sending those requests to the DOE mailbox and forwarding the SPDM responses back
@@ -603,9 +603,9 @@ Binding an interface and a TVM together goes through the following steps:
    its TCB through the `sbi_covg_start_interface()` `COVG` ABI.
 7. Through regular discovery mechanisms (ACPI, PCI bus scanning), the TVM
    detects the assigned TDI. It is important to note that the TDI configuration
-   space, including its BARs, is emulated by the host security domain manager.
+   space, including its BARs, is emulated by the host supervisor domain manager.
    The TDI MMIO ranges are mapped into the TVM address space by the host
-   security domain manager, through the `sbi_covh_add_tvm_interface_region()`
+   supervisor domain manager, through the `sbi_covh_add_tvm_interface_region()`
    `COVH` ABI.
 8. Before using the TDI, the TVM must
    xref:tdi-acceptation[accept it into its TCB]. Moreover, the TVM must not use

--- a/specification/09-coveio_abi.adoc
+++ b/specification/09-coveio_abi.adoc
@@ -20,9 +20,9 @@ struct sbiret sbi_covh_register_iommu(unsigned long iommu_id,
 -----
 
 Registers an IOMMU (`iommu_id`) with a TSM. The `msi_cfg` MSI vectors are
-allocated by the host security domain manager (e.g. the host VMM).
+allocated by the host supervisor domain manager (e.g. the host VMM).
 
-The TSM configures the IOMMU TSM security domain programming interface
+The TSM configures the IOMMU TSM supervisor domain programming interface
 `s_msi_cfg_table` with the provided MSI vectors.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -44,7 +44,7 @@ The possible error codes returned in `sbiret.error` are shown below.
 struct sbiret sbi_covh_notify_iommu_msi(unsigned long iommu_id);
 -----
 
-Notifies the TSM about a pending MSI for the TSM security domain.
+Notifies the TSM about a pending MSI for the TSM supervisor domain.
 
 When servicing this request, the TSM must first verify that there are pending
 MSIs, by reading the IOMMU `s_ipsr` register from the IOMMU TSM security
@@ -505,7 +505,7 @@ Maps a TVM MMIO region (from `gpa_address`, `size` bytes long) to a
 `TDISP`-reported physical region (`hpa_addr`).
 
 The TVM uses that function to verify from the TSM that all the device interface
-MMIO regions exposed by the host security domain manager are correctly mapped to
+MMIO regions exposed by the host supervisor domain manager are correctly mapped to
 the trusted `TDISP`-reported MMIO regions. The TSM will enable those mappings
 if the TVM calls the starts the device interface through the
 `sbi_covg_start_interface` function.


### PR DESCRIPTION
As a shortened version of supervisor domain security manager, to be aligned with the Smmtt spec.

Fixes #88