### PR TITLE
specification: Clean up and fix contributors section

### DIFF
--- a/src/01-contributors.adoc
+++ b/src/01-contributors.adoc
@@ -1,9 +1,5 @@
 == Contributors
 
-This RISC-V specification has been contributed to directly or indirectly by:
+This RISC-V specification has been contributed to directly or indirectly by (in alphabetical order):
 
-[%hardbreaks]
-* Samuel Ortiz <sameo@rivosinc.com>
-* Jiewen Yao <jiewen.yao@intel.com>
-* Ravi Sahita <ravi@rivosinc.com>
-* Vedvyas Shanbhogue <ved@rivosinc.com>
+Jiewen Yao (Editor), Kevin Broch, Osman Koyuncu, Ravi Sahita, Samuel Ortiz (Editor), Steven Bellock, Vedvyas Shanbhogue


### PR DESCRIPTION
Make it follow the same format as other specs, and add a few missing names.