### PR TITLE
specifications: Typo fixes

### DIFF
--- a/src/02-intro.adoc
+++ b/src/02-intro.adoc
@@ -5,8 +5,8 @@
 The RISC-V Confidential VM Extension <<CoVE>> specification provides
 application and virtualized workloads with data confidentiality and integrity,
 addressing one of the major datacenter security challenges. By building a
-miminized Trusted Computing Base (TCB), the CoVE interfaces manage to isolate
-workloads from each others but also from untrusted domain host software
+minimized Trusted Computing Base (TCB), the CoVE interfaces manage to isolate
+workloads from each other but also from untrusted domain host software
 components (e.g. the hypervisor). CoVE implementations create a Confidential
 Computing (<<CC>>) framework that allows for mitigating the risks that guest
 owners are exposed to when running their workloads on shared infrastructures
@@ -48,7 +48,7 @@ may also degrade I/O performance even further.
 
 Ideally, a secure and performant CoVE I/O framework would rely on the ability
 for hypervisor-assigned devices to directly access TVMs confidential memory,
-while maintaining the guest confidentality and integrity protection already
+while maintaining the guest confidentiality and integrity protection already
 provided by the CoVE security model. Building such a framework requires
 enhancing both the host software stack and the assigned devices with new
 protection mechanisms. In addition to the existing CoVE defined capabilities,

--- a/src/04-requirements.adoc
+++ b/src/04-requirements.adoc
@@ -201,7 +201,7 @@ IOMMUs:: For each IOMMU present in the platform:
 PCIe Root Ports:: For each PCIe Root Ports present in the platform:
 * A PCIe Segment:Bus:Device:Function identifier.
 * The IOMMU identifier the RP is bound to.
-* The list of all MMIO ranges routed throught that RP.
+* The list of all MMIO ranges routed through that RP.
 * The RP ECAM base address.
 * All downstream PCIe Endpoints linked to that RP, identified by their PCIe RID
 (i.e. the device PCIe Bus:Device:Function triplet).
@@ -254,7 +254,7 @@ M-mode privileges.
 
 === Guest
 
-A TVM guest must verify and explictly accept any TDI into their TCBs. The TSM
+A TVM guest must verify and explicitly accept any TDI into their TCBs. The TSM
 prevents TDIs from directly accessing the TVM confidential memory and prevents
 the TVM from doing memory mapped I/O with TDIs, unless the TVM guest accepts
 the TDI.

--- a/src/05-security_model.adoc
+++ b/src/05-security_model.adoc
@@ -192,7 +192,7 @@ from the following adversaries:
      - The TSM must not enable Trusted MMIO mappings for an assigned TDI until
        the TVM accepts it.
      - The TVM receives the TDI device interface report through TDISP, via the
-       the TSM CoVE-IO guest ABI. This report is trusted by the TVM and contains
+       TSM CoVE-IO guest ABI. This report is trusted by the TVM and contains
        the trusted MMIO ranges and order in which they must be mapped to the TVM
        address space.
      - The TVM must explicitly accept the reported MMIO ranges, and the TSM must
@@ -288,7 +288,7 @@ from the following adversaries:
 
      - The TSM must ensure a TDI is assigned to only one TVM. Once the
        TDI is assigned, it cannot be assigned to the other TVM. The TDI can be
-       assigned to the other one, only after it is stoped.
+       assigned to the other one, only after it is stopped.
      - The TSM must ensure Trusted MMIO is mapped to only one TVM. Once the
        MMIO is mapped, it cannot be mapped to the other TVM. The MMIO can be
        mapped to the other one, only after it is unmapped.
@@ -312,7 +312,7 @@ from the following adversaries:
 
 5+^| **Description**
 5+| A skilled hardware adversary with system physical access probes or places an
-    interposer in the PCIe physical link. It can then eavesdrop, replay or event
+    interposer in the PCIe physical link. It can then eavesdrop, replay or even
     tamper with a TVM confidential data.
 
 5+^| **Mitigations**
@@ -437,7 +437,7 @@ from the following adversaries:
     address (GPA) to host physical address (HPA) mappings to create
     inconsistencies between the TVM and its assigned TDI mappings for the same
     GPA ranges. +
-    The TDI writes physical adresses that are different than the ones the TVM
+    The TDI writes physical addresses that are different than the ones the TVM
     programmed it with, and tampers the TVM confidential memory. +
     Moreover, the TVM memory reads from the intended GPA return results that are
     inconsistent with the actual device operation.
@@ -451,7 +451,7 @@ from the following adversaries:
     - The TSM must guarantee that the DMA translation table for a TDI under its
       control is consistent with the G-stage tables for the TVM the TDI is
       bound to.
-    - The TVM must accept the DMA translation table explictely.
+    - The TVM must accept the DMA translation table explicitly.
     - The TSM must not enable DMA translation table until the TVM accepts the TDI.
 
 |===

--- a/src/07-theory_operations.adoc
+++ b/src/07-theory_operations.adoc
@@ -23,7 +23,7 @@ RISC-V IOMMU Register Programming Interface (RPI), which could range from an
 actual IOMMU instance to an MPT-enforced, memory-mapped access to a physically
 partitioned IOMMU.
 
-This exclusvely assigned IOMMU RPI allows the TSM to enforce the integrity of
+This exclusively assigned IOMMU RPI allows the TSM to enforce the integrity of
 address translations and protection from DMA into confidential memory, as well
 as interrupts originating from TDIs assigned to TVMs under the TSM control.
 
@@ -243,7 +243,7 @@ DSM running in either the platform ROT or a physical PCIe device.
 The secured control plane is based on the SPDM protocol and is an encrypted,
 integrity-protected software session that is used for passing TDISP and IDE_KM
 messages between the TSM and the DSM.
-The data place is a hardware session based on the PCIe Integrity and Data
+The data plane is a hardware session based on the PCIe Integrity and Data
 Encryption (IDE) specification and is used to secure the PCIe TLPs.
 
 When the hosting Supervisor Domain detects a new TEE-IO capable device, it must
@@ -263,7 +263,7 @@ IDE link between the device and the TSM.
 ==== SPDM Session
 
 The first step for initializing a TEE-IO capable device is to establish a
-secured SPDM session between the TSM an the device. The secured SPDM sessions
+secured SPDM session between the TSM and the device. The secured SPDM sessions
 will then be used to carry `TDISP` and `IDE_KM` messages, in order to
 respectively secure the physical link between the device and its PCIe root port,
 and for binding or unbinding TDIs to or from a TVM.
@@ -394,7 +394,7 @@ The TSM handles these requests sent by the TVM via the
 1. Retrieving the full device connection transcript from the host, through
    the `sbi_covh_get_device_connection_transcript()` ABI.
 
-2. Verifying the transcript's digest against the its internal map to ensure
+2. Verifying the transcript's digest against its internal map to ensure
    integrity.
 
 3. Returning the requested data based on the `transcript_element_id` value.
@@ -436,7 +436,7 @@ The hosting Supervisor Domain manager is responsible for:
 
 1. Generating and managing system wide PCIe stream IDs.
 2. Setting the device PCIe device IDE PCI Extended Capability.
-3. Programing the PCIe switch between the device and PCIe root port, such as
+3. Programming the PCIe switch between the device and PCIe root port, such as
    IDE Control Register - Flow-Through IDE Stream Enabled.
 4. Initiating the IDE link setup.
 5. Initiating IDE keys refresh.
@@ -666,7 +666,7 @@ Loop 3 times - TSM requests the Device to stop using the IDE stream Rx key (For 
      VMM ->> TSM: [COVH] - spdm_resp(IDE_KM_K_GOSTOP_ACK)
 end
 
-Loop 3 times - TSM requests the TP to stop using the IDE stream Rx key (For each sub-stream)
+Loop 3 times - TSM requests the RP to stop using the IDE stream Rx key (For each sub-stream)
      TSM ->> RDSM: [COVT] - sbi_covt_set_stop_rp_ide_key(rp_id, key_desc)
      RDSM ->> RootPort: Clear IDE Rx key
 end
@@ -858,7 +858,7 @@ into its TCB:
    across a secured SPDM and physical link is mandatory but not sufficient. The
    TVM must also attest to the physical device trustworthiness in order to
    decide if it can accept one of its TDIs into its TCB. A TVM can trust a PCIe
-   device by first authentictating it. Once authenticated, the TVM challenges
+   device by first authenticating it. Once authenticated, the TVM challenges
    the device and then verifies its measurements:
    a. First the TVM must first verify the authenticity of the device by getting
       its certificate chain from the TSM, through the
@@ -1113,12 +1113,12 @@ end
 In TEE-IO architecture, when connecting to a device, a TSM establishes an SPDM
 session and an IDE session. Both sessions use AES-GCM-256 keys to protect the
 data. As such, the hosting Supervisor Domain manager needs to update the session
-keys before the use of keys reach to the limit.
+keys before the use of keys reach the limit.
 
 ==== SPDM Session Key Update
 
 SPDM session key update is managed by SPDM KEY_UPDATE command.
-The TSM shall count the usage of SPDM session keys, also knowns as the 64bit
+The TSM shall count the usage of SPDM session keys, also known as the 64bit
 `sequence number` defined in <<SecuredSPDM>>.
 
 Whenever the TSM generates and encrypts SPDM messages to support the host
@@ -1158,7 +1158,7 @@ The TSM and DSM should support AEAD Limit Counter feature described in
 === Session Heartbeat
 
 A device may require SPDM session heartbeat to ensure the session is kept alive
-on the host side. If the both TSM and DSM support SPDM heartbeat,
+on the host side. If both the TSM and DSM support SPDM heartbeat,
 the device may return a non-zero `HeartbeatPeriod` in `KEY_EXCHANGE_RSP`
 response message.
 
@@ -1173,7 +1173,7 @@ When a SPDM heartbeat is required, the VMM must initiate an SPDM heartbeat
 
 When combined together, the flows and ABIs described in the previous sections
 are used to build the lifecycle of a TDISP capable device on a CoVE-IO
-compatible platform, as illustrated in the follwing figure:
+compatible platform, as illustrated in the following figure:
 
 [[COVE_IO_LIFECYCLE]]
 .Device and Interface Lifecycle
@@ -1201,7 +1201,7 @@ must first require the TSM to connect (step 1) to the physical device through
 secured SPDM. As part of servicing that request, the TSM also protects the
  physical link with PCIe IDE.
 
-The hosting Supervisor Domain manager is also required to explictly add the TDI
+The hosting Supervisor Domain manager is also required to explicitly add the TDI
 MMIO regions to the TDI (step 2). The TSM can prepare and allocate the TVM
 second stage page tables and map those I/O regions into the guest physical
 address space. The TSM does not enable those tables until the TVM starts the

--- a/src/08-attestation.adoc
+++ b/src/08-attestation.adoc
@@ -238,5 +238,5 @@ Providing the signed <<SPDM>> measurement transcript has multiple benefits:
 | Device Verifier Code in TVM report | TVM Verifier                       | TVM Verifier or Stub Function to Verifier Service
 | Device Policy Data in TVM report   | Endorsement and Reference Value    | Remote Service URL and Public Cert (trust anchor)
 | Device Policy Update in TVM report | Signer of Update (as trust anchor) | N/A
-| Device identity NOT in TVM report  | Device Measurement and Certifcate  | Device Measurement and Certifcate
+| Device identity NOT in TVM report  | Device Measurement and Certificate  | Device Measurement and Certificate
 |===

--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -188,7 +188,7 @@ Binds a TVM and a device interface together.
 The TSM returns an error if a secured SPDM session is not established with the
 DSM or if a stream IDE link is not set up.
 
-After this calls completes successfully, the `device_id_interface` is in the
+After this call completes successfully, the `device_id_interface` is in the
 TDISP `CONFIG_LOCKED` state.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -212,7 +212,7 @@ struct sbiret sbi_covh_unbind_interface()(unsigned long tvm_id,
 
 Unbinds a device interface from a TVM.
 
-After this calls completes successfully, the `device_id_interface` is moved
+After this call completes successfully, the `device_id_interface` is moved
 back to the TDISP `CONFIG_UNLOCKED` state, from one of the `CONFIG_LOCKED`,
 `CONFIG_UNLOCKED` or `CONFIG_ERROR` states.
 
@@ -334,7 +334,7 @@ struct sbiret sbi_covg_get_device_link(unsigned long device_if_id);
 Gets the status of the link between the physical device hosting `device_if_id`
 and the TVM. This covers both the SPDM and IDE links.
 
-Returns the a link status bitmap through `sbiret.value`.
+Returns a link status bitmap through `sbiret.value`.
 
 [source, C]
 -------
@@ -422,7 +422,7 @@ enum sbi_covg_transcript_element {
       * `device_if_id`.
       * This is the concatenation of the `TDISP_GET_VERSION`, `TDISP_VERSION`,
       * `TDISP_GET_CAPABILITIES` and `TDISP_CAPABILITIES` TDISP messages from
-      * the trasncript.
+      * the transcript.
       * It includes the `TSM_CAPS`, `DSM_CAPS`, `REQ_MSGS_SUPPORTED`, and
       * `LOCK_INTERFACE_FLAGS_SUPPORTED`, etc.
       */
@@ -474,8 +474,8 @@ nonce on behalf of the TVM.
 
 `msmt_req_attr` is used as the measurement request attributes in SPDM
 `GET_MEASUREMENT` request `param1` field. Only `RawBitStreamRequested` bit is
-valid and the rest bits are igored. The last `GET_MEASUREMENT` request must
-set `SignatureRequested` bit to request the digital signaure of the measurement
+valid and the rest bits are ignored. The last `GET_MEASUREMENT` request must
+set `SignatureRequested` bit to request the digital signature of the measurement
 transcript.
 
 Both `msmt_addr_out` and `nonce_addr` must be 4KB-aligned.
@@ -580,7 +580,7 @@ Maps a TVM MMIO region (from `gpa_address`, `size` bytes long) to a
 The TVM uses that function to verify from the TSM that all the device interface
 MMIO regions exposed by the host Supervisor Domain manager are correctly mapped to
 the trusted `TDISP`-reported MMIO regions. The TSM will enable those mappings
-if the TVM calls the starts the device interface through the
+if the TVM starts the device interface through the
 `sbi_covg_start_interface` function.
 
 All of `gpa_addr`, `hpa_addr` and `size` values must be 4KB-aligned.
@@ -609,7 +609,7 @@ The TVM calls this function in order to accept a bound device interface into its
 TCB. While servicing this request, the TSM moves the device interface TDISP
 state from `CONFIG_LOCKED` to `RUN`.
 
-After this calls completes successfully, the device interface I/O is ready and
+After this call completes successfully, the device interface I/O is ready and
 available for the bound TVM.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -636,7 +636,7 @@ Stops a bound device interface.
 The TVM calls this function for either removing a bound device interface from
 its TCB or initially rejecting it.
 
-After this calls completes successfully, the device interface and the TVM are
+After this call completes successfully, the device interface and the TVM are
 no longer bound together.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -782,7 +782,7 @@ content to encrypt transmitted PCIe TLPs for the corresponding stream and
 sub-streams combination.
 
 If the enabled key is a receiver key, the `rp_id` Root Port prepares for
-receiving and decrypting PCIe TLPs on the the corresponding stream and
+receiving and decrypting PCIe TLPs on the corresponding stream and
 sub-streams combination.
 
 Once enabled, a key can not be cleared or reprogrammed. It must be


### PR DESCRIPTION
Fixed all obvious typos in the spec.