### PR TITLE
specifications: Split addresses into _lo and _hi 

### DIFF
--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -7,6 +7,17 @@ As a <<CoVE>> SBI extension, CoVE-IO has a reserved CoVE Function ID (FID)
 namespace. For all three CoVE EID (`COVH`, `COVI` and `COVG`), the CoVE-IO FIDs
 must be in the `[1024:1087]` range.
 
+=== Physical Address Parameters
+
+On RV32, physical addresses can be wider than XLEN (e.g., 34 bits with Sv32).
+Following the SBI specification convention, all physical address parameters in
+CoVE-IO SBI functions are split into a pair of `unsigned long` values:
+
+* `_lo` contains the low XLEN bits of the physical address.
+* `_hi` contains the high bits of the physical address.
+
+On RV64, the `_hi` parameter must be zero.
+
 === CoVE IO Host Extension (EID #0x434F5648 "COVH")
 
 ==== Physical Device Management
@@ -16,8 +27,10 @@ must be in the `[1024:1087]` range.
 [source, C]
 -----
 struct sbiret sbi_covh_connect_device(unsigned long device_id,
-                                      unsigned long ide_stream_desc_addr,
-                                      unsigned long connection_data_out_addr,
+                                      unsigned long ide_stream_desc_addr_lo,
+                                      unsigned long ide_stream_desc_addr_hi,
+                                      unsigned long connection_data_out_addr_lo,
+                                      unsigned long connection_data_out_addr_hi,
                                       unsigned long connection_data_size);
 -----
 
@@ -62,7 +75,7 @@ Domain manager at `connection_data_out_addr`, structured as follows:
 | 5             | ConnectionTranscript       | `ConnectionTranscriptLength` | Device connection transcript
 |===
 
-`connection_data_out_addr` must be 4KB-aligned and points to a memory region
+`connection_data_out_addr` must be 4KB-aligned and point to a memory region
 that is accessible to both the host Supervisor Domain manager and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -110,7 +123,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 -----
 struct sbiret sbi_covh_add_tvm_interface_region(unsigned long tvm_id,
                                                 unsigned long device_if_id,
-                                                unsigned long base_addr,
+                                                unsigned long base_addr_lo,
+                                                unsigned long base_addr_hi,
                                                 unsigned long region_len);
 -----
 
@@ -145,7 +159,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 -----
 struct sbiret sbi_covh_reclaim_tvm_interface_region(unsigned long tvm_id,
                                                     unsigned long device_if_id,
-                                                    unsigned long base_addr,
+                                                    unsigned long base_addr_lo,
+                                                    unsigned long base_addr_hi,
                                                     unsigned long region_len);
 -----
 
@@ -295,7 +310,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covh_get_device_connection_transcript(unsigned long device_id,
-                                                        unsigned long transcript_data_out_addr,
+                                                        unsigned long transcript_data_out_addr_lo,
+                                                        unsigned long transcript_data_out_addr_hi,
                                                         unsigned long transcript_data_size);
 -----
 
@@ -363,7 +379,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 struct sbiret sbi_covg_get_device_connection_transcript(unsigned long device_if_id,
                                                         unsigned long transcript_element_id,
                                                         unsigned long transcript_element_parameter,
-                                                        unsigned long data_out_addr,
+                                                        unsigned long data_out_addr_lo,
+                                                        unsigned long data_out_addr_hi,
                                                         unsigned long data_size);
 -----
 
@@ -449,8 +466,10 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covg_get_device_measurements(unsigned long device_if_id,
-                                               unsigned long msmt_req_addr,
-                                               unsigned long msmt_out_addr,
+                                               unsigned long msmt_req_addr_lo,
+                                               unsigned long msmt_req_addr_hi,
+                                               unsigned long msmt_out_addr_lo,
+                                               unsigned long msmt_out_addr_hi,
                                                unsigned long msmt_size);
 -----
 
@@ -502,7 +521,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covg_get_interface_report(unsigned long device_if_id,
-                                           unsigned long if_report_out_addr,
+                                           unsigned long if_report_out_addr_lo,
+                                           unsigned long if_report_out_addr_hi,
                                            unsigned long if_report_size);
 -----
 
@@ -573,12 +593,14 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 ----
 struct sbiret sbi_covg_map_interface_mmio(unsigned long device_if_id,
-                                         unsigned long gpa_addr,
-                                         unsigned long hpa_addr,
+                                         unsigned long gpa_addr_lo,
+                                         unsigned long gpa_addr_hi,
+                                         unsigned long hpa_addr_lo,
+                                         unsigned long hpa_addr_hi,
                                          unsigned long size);
 ----
 
-Maps a TVM MMIO region (from `gpa_address`, `size` bytes long) to a
+Maps a TVM MMIO region (from `gpa_addr`, `size` bytes long) to a
 `TDISP`-reported physical region (`hpa_addr`).
 
 The TVM uses that function to verify from the TSM that all the device interface
@@ -664,8 +686,10 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covt_program_rp_ide_key(unsigned long rp_id,
-                                          unsigned long key_desc_addr,
-                                          unsigned long key_data_addr);
+                                          unsigned long key_desc_addr_lo,
+                                          unsigned long key_desc_addr_hi,
+                                          unsigned long key_data_addr_lo,
+                                          unsigned long key_data_addr_hi);
 -----
 
 Programs a PCIe IDE key into the `rp_id` PCIe Root Port. This is functionally
@@ -774,7 +798,8 @@ its status is `Unknown`.
 [source, C]
 -----
 struct sbiret sbi_covt_set_go_rp_ide_key(unsigned long rp_id,
-                                         unsigned long key_desc_addr);
+                                         unsigned long key_desc_addr_lo,
+                                         unsigned long key_desc_addr_hi);
 -----
 
 Enables a previously programmed IDE key for the `rp_id` PCIe Root Port. This
@@ -810,7 +835,8 @@ disabled first.
 [source, C]
 -----
 struct sbiret sbi_covt_set_stop_rp_ide_key(unsigned long rp_id,
-                                           unsigned long key_desc_addr);
+                                           unsigned long key_desc_addr_lo,
+                                           unsigned long key_desc_addr_hi);
 -----
 
 Disables a previously enabled IDE key for the `rp_id` PCIe Root Port. This
@@ -836,7 +862,8 @@ Once disabled, a key status moves back to the `Programmed` state.
 [source, C]
 -----
 struct sbiret sbi_covt_rp_ide_key_status(unsigned long rp_id,
-                                         unsigned long key_desc_addr);
+                                         unsigned long key_desc_addr_lo,
+                                         unsigned long key_desc_addr_hi);
 -----
 
 Gets the status of a PCIe Root Port IDE key.
@@ -895,7 +922,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covt_program_rp_ide_stream(unsigned long rp_id,
-                                             unsigned long ide_stream_desc_addr);
+                                             unsigned long ide_stream_desc_addr_lo,
+                                             unsigned long ide_stream_desc_addr_hi);
 -----
 
 Programs the IDE Extended Capability of PCIe Root Port `rp_id` based on the

--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -449,8 +449,7 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covg_get_device_measurements(unsigned long device_if_id,
-                                               unsigned long nonce_addr,
-                                               unsigned long msmt_req_attr,
+                                               unsigned long msmt_req_addr,
                                                unsigned long msmt_out_addr,
                                                unsigned long msmt_size);
 -----
@@ -465,20 +464,23 @@ pairs that are exchanged between the SPDM measurement requester and the
 responder. Only the last `MEASUREMENTS` shall include the digital signature of
 the measurement transcript.
 
-The `nonce_addr` parameter points at an optional 32 bytes long buffer holding a
-cryptographic nonce.
+The `msmt_req_addr` parameter points at a measurement request descriptor,
+structured as follows:
 
-For any non zero value, the nonce is used as the SPDM `GET_MEASUREMENTS` request
-`Nonce` field. When set to `0x0`, the TSM ignores this argument and generates a
-nonce on behalf of the TVM.
+[#table_sbi_covh_measurement_request]
+.CoVE Measurement Request Descriptor
+[options=header]
+|===
+| *Byte Offset* | *Field*           | *Size (bytes)* | *Description*
+| 00h           | COVEIOVersion     | 1              | CoVE-IO version
+| 01h           | DescriptorLength  | 4              | Total size of this descriptor, in bytes
+| 05h           | MsmtReqAttr       | 1              | SPDM `GET_MEASUREMENTS` request attributes (`Param1` field). All bits defined as valid by the <<SPDM>> `GET_MEASUREMENTS` request `Param1` field are supported, except for the `SignatureRequested` bit which is reserved and must be 0. The TSM sets the `SignatureRequested` bit in the last `GET_MEASUREMENTS` request on behalf of the TVM.
+| 06h           | SlotID            | 1              | SPDM `GET_MEASUREMENTS` request `SlotIDParam`. Identifies the slot number of the certificate chain to use for signing the measurement transcript. This field is optional: if all bits are 0, the TSM uses the default slot ID 0. Only bits 3:0 are valid; bits 7:4 are reserved and must be 0.
+| 07h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. If all 32 bytes are zero, the TSM generates a nonce on behalf of the TVM and ignores this field.
+|===
 
-`msmt_req_attr` is used as the measurement request attributes in SPDM
-`GET_MEASUREMENT` request `param1` field. Only `RawBitStreamRequested` bit is
-valid and the rest bits are ignored. The last `GET_MEASUREMENT` request must
-set `SignatureRequested` bit to request the digital signature of the measurement
-transcript.
-
-Both `msmt_out_addr` and `nonce_addr` must be 4KB-aligned.
+Both `msmt_out_addr` and `msmt_req_addr` must be 4KB-aligned, and both must
+point to memory regions accessible to both the TVM and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -488,6 +490,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 |===
 | Error code              | Description
 | SBI_SUCCESS             | The operation completed successfully.
+| SBI_ERR_INVALID_PARAM   | `MsmtReqAttr` contains reserved bits that are set, `SlotID` contains reserved bits that are set, or `DescriptorLength` is inconsistent with the `COVEIOVersion`.
+| SBI_ERR_INVALID_ADDRESS | `msmt_req_addr` or `msmt_out_addr` is invalid, misaligned, or not accessible to both the TVM and the TSM.
 | SBI_ERR_FAILED          | The operation failed for unknown reasons.
 |===
 

--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -75,8 +75,8 @@ Domain manager at `connection_data_out_addr`, structured as follows:
 | 5             | ConnectionTranscript       | `ConnectionTranscriptLength` | Device connection transcript
 |===
 
-`connection_data_out_addr` must be 4KB-aligned and point to a memory region
-that is accessible to both the host Supervisor Domain manager and the TSM.
+`connection_data_out_addr` must point to a memory region that is accessible to
+both the host Supervisor Domain manager and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -320,8 +320,8 @@ device. The data is formatted according to the
 [Device Connection Transcript](#function-cove-host-connect-device-fid-1026)
 structure.
 
-`transcript_data_out_addr` must be 4KB-aligned and points to a memory region
-that is accessible to both the host Supervisor Domain manager and the TSM.
+`transcript_data_out_addr` must point to a memory region that is accessible to
+both the host Supervisor Domain manager and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -447,7 +447,7 @@ enum sbi_covg_transcript_element {
 };
 -----
 
-`data_out_addr` must be 4KB-aligned.
+`data_out_addr` must point to memory regions accessible to both the TVM and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -498,8 +498,8 @@ structured as follows:
 | 07h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. It is the TVM's responsibility to generate and provide a valid nonce through that field.
 |===
 
-Both `msmt_out_addr` and `msmt_req_addr` must be 4KB-aligned, and both must
-point to memory regions accessible to both the TVM and the TSM.
+Both `msmt_out_addr` and `msmt_req_addr` must point to memory regions accessible
+to both the TVM and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
 
@@ -531,7 +531,8 @@ Gets the TDISP interface report for the device interface.
 The TSM returns the interface report, as defined by the <<TDISP>> TDI Report
 Structure, at the `if_report_out_addr` address.
 
-`if_report_out_addr` must be 4KB-aligned.
+`if_report_out_addr` must point to memory regions accessible to both the TVM and
+the TSM..
 
 The possible error codes returned in `sbiret.error` are shown below.
 

--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -7,6 +7,17 @@ As a <<CoVE>> SBI extension, CoVE-IO has a reserved CoVE Function ID (FID)
 namespace. For all three CoVE EID (`COVH`, `COVI` and `COVG`), the CoVE-IO FIDs
 must be in the `[1024:1087]` range.
 
+=== Physical Address Parameters
+
+On RV32, physical addresses can be wider than XLEN (e.g., 34 bits with Sv32).
+Following the SBI specification convention, all physical address parameters in
+CoVE-IO SBI functions are split into a pair of `unsigned long` values:
+
+* `_lo` contains the low XLEN bits of the physical address.
+* `_hi` contains the high bits of the physical address.
+
+On RV64, the `_hi` parameter must be zero.
+
 === CoVE IO Host Extension (EID #0x434F5648 "COVH")
 
 ==== Physical Device Management
@@ -16,8 +27,10 @@ must be in the `[1024:1087]` range.
 [source, C]
 -----
 struct sbiret sbi_covh_connect_device(unsigned long device_id,
-                                      unsigned long ide_stream_desc_addr,
-                                      unsigned long connection_data_out_addr,
+                                      unsigned long ide_stream_desc_addr_lo,
+                                      unsigned long ide_stream_desc_addr_hi,
+                                      unsigned long connection_data_out_addr_lo,
+                                      unsigned long connection_data_out_addr_hi,
                                       unsigned long connection_data_size);
 -----
 
@@ -62,7 +75,7 @@ Domain manager at `connection_data_out_addr`, structured as follows:
 | 5             | ConnectionTranscript       | `ConnectionTranscriptLength` | Device connection transcript
 |===
 
-`connection_data_out_addr` must be 4KB-aligned and points to a memory region
+`connection_data_out_addr` must be 4KB-aligned and point to a memory region
 that is accessible to both the host Supervisor Domain manager and the TSM.
 
 The possible error codes returned in `sbiret.error` are shown below.
@@ -110,7 +123,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 -----
 struct sbiret sbi_covh_add_tvm_interface_region(unsigned long tvm_id,
                                                 unsigned long device_if_id,
-                                                unsigned long base_addr,
+                                                unsigned long base_addr_lo,
+                                                unsigned long base_addr_hi,
                                                 unsigned long region_len);
 -----
 
@@ -145,7 +159,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 -----
 struct sbiret sbi_covh_reclaim_tvm_interface_region(unsigned long tvm_id,
                                                     unsigned long device_if_id,
-                                                    unsigned long base_addr,
+                                                    unsigned long base_addr_lo,
+                                                    unsigned long base_addr_hi,
                                                     unsigned long region_len);
 -----
 
@@ -295,7 +310,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covh_get_device_connection_transcript(unsigned long device_id,
-                                                        unsigned long transcript_data_out_addr,
+                                                        unsigned long transcript_data_out_addr_lo,
+                                                        unsigned long transcript_data_out_addr_hi,
                                                         unsigned long transcript_data_size);
 -----
 
@@ -363,7 +379,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 struct sbiret sbi_covg_get_device_connection_transcript(unsigned long device_if_id,
                                                         unsigned long transcript_element_id,
                                                         unsigned long transcript_element_parameter,
-                                                        unsigned long data_out_addr,
+                                                        unsigned long data_out_addr_lo,
+                                                        unsigned long data_out_addr_hi,
                                                         unsigned long data_size);
 -----
 
@@ -449,8 +466,10 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covg_get_device_measurements(unsigned long device_if_id,
-                                               unsigned long msmt_req_addr,
-                                               unsigned long msmt_out_addr,
+                                               unsigned long msmt_req_addr_lo,
+                                               unsigned long msmt_req_addr_hi,
+                                               unsigned long msmt_out_addr_lo,
+                                               unsigned long msmt_out_addr_hi,
                                                unsigned long msmt_size);
 -----
 
@@ -476,7 +495,7 @@ structured as follows:
 | 01h           | DescriptorLength  | 4              | Total size of this descriptor, in bytes
 | 05h           | MsmtReqAttr       | 1              | SPDM `GET_MEASUREMENTS` request attributes (`Param1` field). All bits defined as valid by the <<SPDM>> `GET_MEASUREMENTS` request `Param1` field are supported, except for the `SignatureRequested` bit which is reserved and must be 0. The TSM sets the `SignatureRequested` bit in the last `GET_MEASUREMENTS` request on behalf of the TVM.
 | 06h           | SlotID            | 1              | SPDM `GET_MEASUREMENTS` request `SlotIDParam`. Identifies the slot number of the certificate chain to use for signing the measurement transcript. This field is optional: if all bits are 0, the TSM uses the default slot ID 0. Only bits 3:0 are valid; bits 7:4 are reserved and must be 0.
-| 07h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. If all 32 bytes are zero, the TSM generates a nonce on behalf of the TVM and ignores this field.
+| 07h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. It is the TVM's responsibility to generate and provide a valid nonce through that field.
 |===
 
 Both `msmt_out_addr` and `msmt_req_addr` must be 4KB-aligned, and both must
@@ -502,7 +521,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covg_get_interface_report(unsigned long device_if_id,
-                                           unsigned long if_report_out_addr,
+                                           unsigned long if_report_out_addr_lo,
+                                           unsigned long if_report_out_addr_hi,
                                            unsigned long if_report_size);
 -----
 
@@ -573,12 +593,14 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 ----
 struct sbiret sbi_covg_map_interface_mmio(unsigned long device_if_id,
-                                         unsigned long gpa_addr,
-                                         unsigned long hpa_addr,
+                                         unsigned long gpa_addr_lo,
+                                         unsigned long gpa_addr_hi,
+                                         unsigned long hpa_addr_lo,
+                                         unsigned long hpa_addr_hi,
                                          unsigned long size);
 ----
 
-Maps a TVM MMIO region (from `gpa_address`, `size` bytes long) to a
+Maps a TVM MMIO region (from `gpa_addr`, `size` bytes long) to a
 `TDISP`-reported physical region (`hpa_addr`).
 
 The TVM uses that function to verify from the TSM that all the device interface
@@ -664,8 +686,10 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covt_program_rp_ide_key(unsigned long rp_id,
-                                          unsigned long key_desc_addr,
-                                          unsigned long key_data_addr);
+                                          unsigned long key_desc_addr_lo,
+                                          unsigned long key_desc_addr_hi,
+                                          unsigned long key_data_addr_lo,
+                                          unsigned long key_data_addr_hi);
 -----
 
 Programs a PCIe IDE key into the `rp_id` PCIe Root Port. This is functionally
@@ -774,7 +798,8 @@ its status is `Unknown`.
 [source, C]
 -----
 struct sbiret sbi_covt_set_go_rp_ide_key(unsigned long rp_id,
-                                         unsigned long key_desc_addr);
+                                         unsigned long key_desc_addr_lo,
+                                         unsigned long key_desc_addr_hi);
 -----
 
 Enables a previously programmed IDE key for the `rp_id` PCIe Root Port. This
@@ -810,7 +835,8 @@ disabled first.
 [source, C]
 -----
 struct sbiret sbi_covt_set_stop_rp_ide_key(unsigned long rp_id,
-                                           unsigned long key_desc_addr);
+                                           unsigned long key_desc_addr_lo,
+                                           unsigned long key_desc_addr_hi);
 -----
 
 Disables a previously enabled IDE key for the `rp_id` PCIe Root Port. This
@@ -836,7 +862,8 @@ Once disabled, a key status moves back to the `Programmed` state.
 [source, C]
 -----
 struct sbiret sbi_covt_rp_ide_key_status(unsigned long rp_id,
-                                         unsigned long key_desc_addr);
+                                         unsigned long key_desc_addr_lo,
+                                         unsigned long key_desc_addr_hi);
 -----
 
 Gets the status of a PCIe Root Port IDE key.
@@ -895,7 +922,8 @@ The possible error codes returned in `sbiret.error` are shown below.
 [source, C]
 -----
 struct sbiret sbi_covt_program_rp_ide_stream(unsigned long rp_id,
-                                             unsigned long ide_stream_desc_addr);
+                                             unsigned long ide_stream_desc_addr_lo,
+                                             unsigned long ide_stream_desc_addr_hi);
 -----
 
 Programs the IDE Extended Capability of PCIe Root Port `rp_id` based on the

--- a/src/09-coveio_abi.adoc
+++ b/src/09-coveio_abi.adoc
@@ -70,9 +70,8 @@ Domain manager at `connection_data_out_addr`, structured as follows:
 [options=header]
 |===
 | *Byte Offset* | *Field*                    | *Size (bytes)*               | *Description*
-| 0             | COVEIOVersion              | 1                            | CoVE-IO version
-| 1             | ConnectionTranscriptLength | 4                            | Size of the `ConnectionTranscript` field that follows, in bytes
-| 5             | ConnectionTranscript       | `ConnectionTranscriptLength` | Device connection transcript
+| 00h           | ConnectionTranscriptLength | 4                            | Size of the `ConnectionTranscript` field that follows, in bytes
+| 04h           | ConnectionTranscript       | `ConnectionTranscriptLength` | Device connection transcript
 |===
 
 `connection_data_out_addr` must point to a memory region that is accessible to
@@ -491,11 +490,9 @@ structured as follows:
 [options=header]
 |===
 | *Byte Offset* | *Field*           | *Size (bytes)* | *Description*
-| 00h           | COVEIOVersion     | 1              | CoVE-IO version
-| 01h           | DescriptorLength  | 4              | Total size of this descriptor, in bytes
-| 05h           | MsmtReqAttr       | 1              | SPDM `GET_MEASUREMENTS` request attributes (`Param1` field). All bits defined as valid by the <<SPDM>> `GET_MEASUREMENTS` request `Param1` field are supported, except for the `SignatureRequested` bit which is reserved and must be 0. The TSM sets the `SignatureRequested` bit in the last `GET_MEASUREMENTS` request on behalf of the TVM.
-| 06h           | SlotID            | 1              | SPDM `GET_MEASUREMENTS` request `SlotIDParam`. Identifies the slot number of the certificate chain to use for signing the measurement transcript. This field is optional: if all bits are 0, the TSM uses the default slot ID 0. Only bits 3:0 are valid; bits 7:4 are reserved and must be 0.
-| 07h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. It is the TVM's responsibility to generate and provide a valid nonce through that field.
+| 00h           | MsmtReqAttr       | 1              | SPDM `GET_MEASUREMENTS` request attributes (`Param1` field). All bits defined as valid by the <<SPDM>> `GET_MEASUREMENTS` request `Param1` field are supported, except for the `SignatureRequested` bit which is reserved and must be 0. The TSM sets the `SignatureRequested` bit in the last `GET_MEASUREMENTS` request on behalf of the TVM.
+| 01h           | SlotID            | 1              | SPDM `GET_MEASUREMENTS` request `SlotIDParam`. Identifies the slot number of the certificate chain to use for signing the measurement transcript. This field is optional: if all bits are 0, the TSM uses the default slot ID 0. Only bits 3:0 are valid; bits 7:4 are reserved and must be 0.
+| 02h           | Nonce             | 32             | Cryptographic nonce to use as the SPDM `GET_MEASUREMENTS` request `Nonce` field. It is the TVM's responsibility to generate and provide a valid nonce through that field.
 |===
 
 Both `msmt_out_addr` and `msmt_req_addr` must point to memory regions accessible


### PR DESCRIPTION
Fixes #172 